### PR TITLE
bump kurtosis engine version to 1.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
-    "kurtosis-engine-api-lib": "1.26.1",
+    "kurtosis-engine-api-lib": "1.27.1",
     "mocha": "^9.1.3",
     "ts-mocha": "^9.0.2",
     "typescript": "^4.3.5"


### PR DESCRIPTION
Kurtosis engine 1.27.1 is the version that users get upgraded to when running `brew upgrade kurtosis-tech/tap/kurtosis-cli` based on instructions from: https://docs.kurtosistech.com/installation.html. Bumping this version allows the tests to pass in the [onboarding exercise](https://github.com/kurtosis-tech/kurtosis-onboarding-experience#step-five-get-an-ethereum-testsuite-5-minutes).

It also was not obvious to me which version of the kurtosis engine users will get upgraded to when running `brew upgrade kurtosis-tech/tap/kurtosis-cli` because when I checked out the tags here: https://github.com/kurtosis-tech/kurtosis-engine-api-lib/tags, there were no labels or endorsed changelogs to indicate which one was the "latest stable"