### PR TITLE
Bump Kurtosis Engine dependency to v1.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This is an Ethereum testsuite containing a single test against a private Ethereu
 To run the suite, execute:
 
 ```
-bash scripts/build-and-run.sh all
+bash scripts/build.sh all
 ```
 
 To see help information, execute:
 
 ```
-bash scripts/build-and-run.sh help
+bash scripts/build.sh help
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
-    "kurtosis-engine-api-lib": "1.26.1",
+    "kurtosis-engine-api-lib": "1.29.0",
     "mocha": "^9.1.3",
     "ts-mocha": "^9.0.2",
     "typescript": "^4.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,22 +933,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-kurtosis-core-api-lib@1.54.1:
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/kurtosis-core-api-lib/-/kurtosis-core-api-lib-1.54.1.tgz#f167c80d09c1c6468c8b5159113dd4bbd0d03040"
-  integrity sha512-69HhQQVcLDJd02+N63HZa6kW8lkzShWyIRRqQsOxCMa3u02b+1nTPb6hUcQ/FxMEfs3LrRSJoEc2kQf4o0cIpg==
-  dependencies:
-    "@grpc/grpc-js" "^1.4.4"
-    "@types/google-protobuf" "^3.15.5"
-    "@types/path-browserify" "^1.0.0"
-    browser-or-node "^2.0.0"
-    google-protobuf "^3.19.1"
-    grpc-web "^1.3.0"
-    loglevel "^1.7.1"
-    neverthrow "^4.2.2"
-    path-browserify "^1.0.1"
-    tar "^6.1.11"
-
 kurtosis-core-api-lib@1.55.0:
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/kurtosis-core-api-lib/-/kurtosis-core-api-lib-1.55.0.tgz#537e98c505a2f7b8bf04e3e116039545301e6b81"
@@ -965,17 +949,33 @@ kurtosis-core-api-lib@1.55.0:
     path-browserify "^1.0.1"
     tar "^6.1.11"
 
-kurtosis-engine-api-lib@1.26.1:
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/kurtosis-engine-api-lib/-/kurtosis-engine-api-lib-1.26.1.tgz#60e44575243b88e50ef4281d5a846abbf280ed3d"
-  integrity sha512-pOYj885ZUoAIQWluoALsqID7S/PWf9mT77iVQvsmMFpOltUi6mXNKMnJ9x5oXpotNVKK8isTMh2gzi0RA8PvpA==
+kurtosis-core-api-lib@1.57.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/kurtosis-core-api-lib/-/kurtosis-core-api-lib-1.57.0.tgz#3814507b1b9c0c62058f71bb00b44e7d6dd94eab"
+  integrity sha512-NtICYhBavwVH45fqnkiZ3uHIRRHdk5zECDNwjML/RZ5GjwNwaES09UW9LN8OPMcxp2MJ/GOc9Rx4swGkRb3AcA==
+  dependencies:
+    "@grpc/grpc-js" "^1.4.4"
+    "@types/google-protobuf" "^3.15.5"
+    "@types/path-browserify" "^1.0.0"
+    browser-or-node "^2.0.0"
+    google-protobuf "^3.19.1"
+    grpc-web "^1.3.0"
+    loglevel "^1.7.1"
+    neverthrow "^4.2.2"
+    path-browserify "^1.0.1"
+    tar "^6.1.11"
+
+kurtosis-engine-api-lib@1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/kurtosis-engine-api-lib/-/kurtosis-engine-api-lib-1.29.0.tgz#6f933fd2a7572516adba8f471d7b83a960bfe577"
+  integrity sha512-PqXLb+Tz78HXnbj5x5m7SIurE6kHdMprzIlj3vf1h9UHzTzbcwd3BKBLoGNo6EQZ9212GSzwMrWotn6K/DL2Kw==
   dependencies:
     "@grpc/grpc-js" "^1.4.4"
     "@types/semver" "^7.3.9"
     browser-or-node "^2.0.0"
     google-protobuf "^3.17.3"
     grpc-web "^1.3.0"
-    kurtosis-core-api-lib "1.54.1"
+    kurtosis-core-api-lib "1.57.0"
     loglevel "^1.7.1"
     neverthrow "^4.2.2"
     semver "^7.3.5"


### PR DESCRIPTION
Fixes #22

The issue was found by [@jelilat](https://github.com/jelilat) and there is also a PR created https://github.com/kurtosis-tech/onboarding-ethereum-testsuite/pull/21/files by her which also fix these issue and issue #20, but I decided to create a new one because this one is bumping all the Kurtosis dependencies to the latest version